### PR TITLE
Add attach-statement and attach-error configuration options

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,12 @@ kamon {
     # Fully qualified name of the implementation of kamon.jdbc.SqlErrorProcessor.
     sql-error-processor = "kamon.jdbc.Jdbc$SqlErrorProcessor$Default"
 
+    # Whether to attach statements to created spans as a tag
+    attach-statement = true
+
+    # Whether to attach exceptions to created spans as an error
+    attach-error = true
+
   }
 
   modules {


### PR DESCRIPTION
Fixes #14 

The only thing I'm not quite confident of in this PR is whether the `applyConfig()` call in the added tests is safe for parallel-execution