### PR TITLE
Fixed instrumentation support for mysql connectorj 8.0 and redshift

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -47,6 +47,7 @@ kanela.modules {
       "^org.h2..*",
       "^org.sqlite..*",
       "^oracle.jdbc..*",
+      "^com.amazon.redshift.jdbc42..*",
       "^com.mysql.jdbc..*",
       "^com.mysql.cj.jdbc..*",
       "^net.sf.log4jdbc..*"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -48,13 +48,16 @@ kanela.modules {
       "^org.sqlite..*",
       "^oracle.jdbc..*",
       "^com.amazon.redshift.jdbc42..*",
+      "^com.amazon.redshift.core.jdbc42..*",
       "^com.mysql.jdbc..*",
       "^com.mysql.cj.jdbc..*",
-      "^net.sf.log4jdbc..*"
-      "^org.mariadb.jdbc..*"
+      "^org.h2.Driver",
+      "^org.h2.jdbc..*",
+      "^net.sf.log4jdbc..*",
+      "^org.mariadb.jdbc..*",
       "^org.postgresql.jdbc..*",
       "^com.microsoft.sqlserver.jdbc..*",
-      "^com.zaxxer.hikari.pool.PoolBase"
+      "^com.zaxxer.hikari.pool.PoolBase",
       "^com.zaxxer.hikari.pool.PoolEntry",
       "^com.zaxxer.hikari.pool.HikariPool",
       "^com.zaxxer.hikari.pool.ProxyConnection",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -48,6 +48,7 @@ kanela.modules {
       "^org.sqlite..*",
       "^oracle.jdbc..*",
       "^com.mysql.jdbc..*",
+      "^com.mysql.cj.jdbc..*",
       "^net.sf.log4jdbc..*"
       "^org.mariadb.jdbc..*"
       "^org.postgresql.jdbc..*",


### PR DESCRIPTION
From the mysql connectorj 8.0 docs:

> The name of the class that implements java.sql.Driver in MySQL Connector/J has changed from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver. The old class name has been deprecated.

Without this change, the driver doesn't get instrumented and we get an exception:
```
java.lang.ClassCastException: com.mysql.cj.jdbc.ConnectionImpl cannot be cast to kamon.instrumentation.jdbc.HasConnectionPoolTelemetry
```

Workaround for play application: 
Add the following to `application.conf`
```
kanela.modules.jdbc.within += "^com.mysql.cj.jdbc..*"
```
